### PR TITLE
type error

### DIFF
--- a/src/TaskManager.php
+++ b/src/TaskManager.php
@@ -5,11 +5,11 @@ namespace App;
 class TaskManager {
     private const DB_FILE = __DIR__ . '/../db/db.json';
 
-    public static function getTasks() {
+    public static function getTasks(): void {
         return json_decode(file_get_contents(self::DB_FILE), true) ?? [];
     }
 
-    public static function addTask($task) {
+    public static function addTask($task): string {
         $tasks = self::getTasks();
         $newTask = ['id' => uniqid(), 'task' => $task];
         $tasks[] = $newTask;


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed return type for `getTasks` method to `void`.

- Added explicit return type `string` for `addTask` method.

- Improved type safety in `TaskManager` class methods.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TaskManager.php</strong><dd><code>Updated method return types in `TaskManager`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/TaskManager.php

<li>Changed <code>getTasks</code> method return type to <code>void</code>.<br> <li> Updated <code>addTask</code> method to return <code>string</code>.<br> <li> Enhanced type definitions for better code reliability.


</details>


  </td>
  <td><a href="https://github.com/RicardoFuhrmann/code-review-project/pull/38/files#diff-85e752ba2f93e0ff6c589bf95385a5a3057502b4e83ded3a0d583ff4348571f2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>